### PR TITLE
Fix issues with xPDT preventing xCertReq from always working

### DIFF
--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -288,7 +288,7 @@ RenewalCert = $thumbprint
             ) -join '' )
 
             Wait-Win32ProcessEnd `
-                -Path "$ENV:SystemRoot\system32\certreq.exe" `
+                -Path $command `
                 -Arguments $arguments `
                 -Credential $Credential
 

--- a/DSCResources/MSFT_xPDT/MSFT_xPDT.psm1
+++ b/DSCResources/MSFT_xPDT/MSFT_xPDT.psm1
@@ -496,15 +496,13 @@ function Get-Win32ProcessArgumentsFromCommandLine
 
 <#
     .SYNOPSIS
-    Starts a Win32 Process using PInvoke or a scheduled task.
+    Starts a Win32 Process using PInvoke.
     .PARAMETER Path
     The full path to the executable to start the process with.
     .PARAMETER Arguments
     The arguments to pass to the executable when starting the process.
     .PARAMETER Credential
     The user account to start the process under.
-    .PARAMETER AsTask
-    This switch triggers the process to be started by a task.
 #>
 function Start-Win32Process
 {
@@ -516,9 +514,7 @@ function Start-Win32Process
 
         [String] $Arguments,
 
-        [PSCredential] $Credential,
-
-        [Switch] $AsTask
+        [PSCredential] $Credential
     )
 
     $getArguments = Get-Arguments $PSBoundParameters ("Path","Arguments","Credential")
@@ -527,43 +523,21 @@ function Start-Win32Process
     {
         if($PSBoundParameters.ContainsKey("Credential"))
         {
-            if($AsTask)
+            try
             {
-                $actionArguments = Get-Arguments $PSBoundParameters `
-                        ("Path",    "Arguments") `
-                        ("Execute", "Argument")
-                if([string]::IsNullOrEmpty($Arguments))
-                {
-                    $null = $AactionArguments.Remove("Argument")
-                }
-                $taskGuid = [guid]::NewGuid().ToString()
-                $action = New-ScheduledTaskAction @ActionArguments
-                $null = Register-ScheduledTask `
-                    -TaskName "xPDT $taskGuid" `
-                    -Action $action `
-                    -User $Credential.UserName `
-                    -Password $Credential.GetNetworkCredential().Password `
-                    -RunLevel Highest
-                $err = Start-ScheduledTask -TaskName "xPDT $taskGuid"
+                Initialize-PInvoke
+                [Source.NativeMethods]::CreateProcessAsUser(`
+                    ("$Path " + $Arguments),`
+                    $Credential.GetNetworkCredential().Domain,`
+                    $Credential.GetNetworkCredential().UserName,`
+                    $Credential.GetNetworkCredential().Password)
             }
-            else
+            catch
             {
-                try
-                {
-                    Initialize-PInvoke
-                    [Source.NativeMethods]::CreateProcessAsUser(`
-                        ("$Path " + $Arguments),`
-                        $Credential.GetNetworkCredential().Domain,`
-                        $Credential.GetNetworkCredential().UserName,`
-                        $Credential.GetNetworkCredential().Password)
-                }
-                catch
-                {
-                    $exception = New-Object System.ArgumentException $_
-                    $errorCategory = [System.Management.Automation.ErrorCategory]::OperationStopped
-                    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, "Win32Exception", $errorCategory, $null
-                    $err = $errorRecord
-                }
+                $exception = New-Object System.ArgumentException $_
+                $errorCategory = [System.Management.Automation.ErrorCategory]::OperationStopped
+                $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord $exception, "Win32Exception", $errorCategory, $null
+                $err = $errorRecord
             }
         }
         else
@@ -600,8 +574,8 @@ function Start-Win32Process
     The arguments passed to the executable of the process to wait for.
     .PARAMETER Credential
     The user account the process will be running under.
-    .PARAMETER Delay
-    The amount of time to wait for the process.
+    .PARAMETER Timeout
+    The milliseconds to wait for the process to start.
 #>
 function Wait-Win32ProcessStart
 {
@@ -616,28 +590,71 @@ function Wait-Win32ProcessStart
 
         [PSCredential] $Credential,
 
-        [Int] $Delay = 1000
+        [Int] $Timeout = 5000
     )
 
     $start = [DateTime]::Now
     $getArguments = Get-Arguments $PSBoundParameters ("Path","Arguments","Credential")
-    do
+    $started = (@(Get-Win32Process @GetArguments).Count -ge 1)
+    While (-not $started -and ([DateTime]::Now - $start).TotalMilliseconds -lt $Timeout)
     {
-        $value = @(Get-Win32Process @GetArguments).Count -ge 1
-    } while(!$value -and ([DateTime]::Now - $start).TotalMilliseconds -lt $Delay)
-
-    return $value
+        Start-Sleep -Seconds 1
+        $started = @(Get-Win32Process @GetArguments).Count -ge 1
+    }
+    return $started
 } # end function Wait-Win32ProcessStart
 
 <#
     .SYNOPSIS
-    Wait for a Win32 process to end.
+    Wait for a Win32 process to stop. This assumes the process was aleady confirmed to have been started by first
+    calling Wait-Win32ProcessStart.
     .PARAMETER Path
     The full path to the executable of the process to wait for.
     .PARAMETER Arguments
     The arguments passed to the executable of the process to wait for.
     .PARAMETER Credential
     The user account the process will be running under.
+    .PARAMETER Timeout
+    The milliseconds to wait for the process to stop.
+#>
+function Wait-Win32ProcessStop
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $Path,
+
+        [String] $Arguments,
+
+        [PSCredential] $Credential,
+
+        [Int] $Timeout = 30000
+    )
+
+    $start = [DateTime]::Now
+    $getArguments = Get-Arguments $PSBoundParameters ("Path","Arguments","Credential")
+    $stopped = (@(Get-Win32Process @GetArguments).Count -eq 0)
+    While (-not $stopped -and ([DateTime]::Now - $start).TotalMilliseconds -lt $Timeout)
+    {
+        Start-Sleep -Seconds 1
+        $stopped = (@(Get-Win32Process @GetArguments).Count -eq 0)
+    }
+    return $stopped
+} # end function Wait-Win32ProcessStop
+
+<#
+    .SYNOPSIS
+    Wait for a Win32 process to complete.
+    .PARAMETER Path
+    The full path to the executable of the process to wait for.
+    .PARAMETER Arguments
+    The arguments passed to the executable of the process to wait for.
+    .PARAMETER Credential
+    The user account the process will be running under.
+    .PARAMETER Timeout
+    The amount of time to wait for the process to end.
 #>
 function Wait-Win32ProcessEnd
 {
@@ -654,22 +671,20 @@ function Wait-Win32ProcessEnd
     )
 
     $getArguments = Get-Arguments $PSBoundParameters ("Path","Arguments","Credential")
-    While (Wait-Win32ProcessStart @getArguments -Delay 1000)
+    # Wait for the process to start
+    if (-not (Wait-Win32ProcessStart @getArguments))
     {
-        Start-Sleep -Seconds 1
+        New-InvalidOperationError `
+            -ErrorId 'ProcessFailedToStartError' `
+            -ErrorMessage ($LocalizedData.ProcessFailedToStartError -f $Path,$Arguments)
     }
-    # Unregister the task if there is one
-    $Tasks = Get-ScheduledTask |
-        Where-Object -FilterScript {
-            ($_.TaskName.Length -ge 4) -and `
-            ($_.TaskName.Substring(0,4) -eq "xPDT") -and `
-            ($_.Actions.Execute -eq $Path) -and `
-            ($_.Actions.Arguments -eq $Arguments)
-        }
-    $Tasks = $Tasks | Where-Object -FilterScript {
-            $_ -ne $null
-        }
-    $Tasks | Unregister-ScheduledTask -Confirm:$false
+    if (-not (Wait-Win32ProcessStop @getArguments))
+    {
+        # The process did not stop.
+        New-InvalidOperationError `
+            -ErrorId 'ProcessFailedToStopError' `
+            -ErrorMessage ($LocalizedData.ProcessFailedToStopError -f $Path,$Arguments)
+    }
 } # end function Wait-Win32ProcessEnd
 
-Export-ModuleMember Start-Win32Process,Wait-Win32ProcessStart,Wait-Win32ProcessEnd
+Export-ModuleMember Start-Win32Process,Wait-Win32ProcessStart,Wait-Win32ProcessStop,Wait-Win32ProcessEnd

--- a/DSCResources/MSFT_xPDT/en-US/MSFT_xPDT.strings.psd1
+++ b/DSCResources/MSFT_xPDT/en-US/MSFT_xPDT.strings.psd1
@@ -3,8 +3,8 @@ ConvertFrom-StringData @'
     AbsolutePathOrFileName = Absolute path or file name expected
     InvalidArgument = Invalid argument: '{0}' with value: '{1}'
     InvalidArgumentAndMessage = {0} {1}
-    ErrorStarting = Failure starting process matching path '{0}'. Message: {1}
-    FailureWaitingForProcessesToStart = Failed to wait for processes to start
+    ProcessFailedToStartError = The process '{0}' with arguments '{1}' failed to start within the specified timeout.
     ProcessStarted = Process matching path '{0}' started in process ID {1}
     ProcessAlreadyStarted = Process matching path '{0}' already started in process ID {1}
+    ProcessFailedToStopError = The process '{0}' with arguments '{1}' failed to stop within the specified timeout.
 '@

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -89,6 +89,9 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
     - Removed unused functions.
     - Renamed functions to standard verb-noun form.
     - Added help to all functions.
+    - Fixed bug in Wait-Win32ProcessEnd that prevented waiting for process to end.
+    - Added Wait-Win32ProcessStop to wait for a process to stop.
+    - Removed unused and broken scheduled task code.
 
 ### 2.1.0.0
 * Fixed xCertReq to support CA Root Name with spaces


### PR DESCRIPTION
    - Fixed bug in Wait-Win32ProcessEnd that prevented waiting for process to end.
    - Added Wait-Win32ProcessStop to wait for a process to stop.
    - Removed unused and broken scheduled task code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iag-nz/xcertificate/8)
<!-- Reviewable:end -->
