### PR TITLE
Removed certificate verification from xCertReq

### DIFF
--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -448,15 +448,6 @@ function Test-TargetResource
             } # if
         } # if
 
-        if (-not $cert.Verify())
-        {
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($LocalizedData.InvalidCertificateMessage -f $Subject,$ca,$cert.Thumbprint)
-                ) -join '' )
-            return $false
-        } # if
-
         # The certificate was found and is OK - so no change required.
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "

--- a/DSCResources/MSFT_xCertReq/en-us/MSFT_xCertReq.strings.psd1
+++ b/DSCResources/MSFT_xCertReq/en-us/MSFT_xCertReq.strings.psd1
@@ -14,7 +14,7 @@ ConvertFrom-StringData @'
     ExpiringCertificateMessage = The certificate found with subject '{0}' issued by {1} with thumbprint '{2}' is about to expire.
     NoValidCertificateMessage = No valid certificate found with subject '{0}' issued by {1}.
     ExpiredCertificateMessage = The certificate found with subject '{0}' issued by {1} with thumbprint '{2}' has expired.
-    InvalidCertificateMessage = Teh certificate found with subject '{0}' issued by {1} with thumbprint '{2}' is inavlid.
+    InvalidCertificateMessage = The certificate found with subject '{0}' issued by {1} with thumbprint '{2}' is inavlid.
     ValidCertificateExistsMessage = Valid certificate '{2}' found with subject '{0}' issued by {1}.
     CertificateReqNotFoundError = Certificate Request file '{0}' not found.
     CertificateCerNotFoundError = Certificate file '{0}' not found.


### PR DESCRIPTION
Removed certificate verification from xCertReq because an network outage would cause certificate reissuance

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iag-nz/xcertificate/10)
<!-- Reviewable:end -->
